### PR TITLE
DNS implementation

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,38 @@
+resource "aws_route53_zone" "rothwell-dev-zone" {
+  name = "rothwell.dev"
+}
+
+resource "aws_route53_record" "rothwell-dev-ns" {
+  zone_id = aws_route53_zone.rothwell-dev-zone.zone_id
+  name    = "rothwell.dev"
+  type    = "NS"
+  ttl     = 172800
+
+  records = [
+    "ns-1389.awsdns-45.org.",
+    "ns-186.awsdns-23.com.",
+    "ns-1887.awsdns-43.co.uk.",
+    "ns-865.awsdns-44.net.",
+  ]
+}
+
+resource "aws_route53_record" "rothwell-dev-soa" {
+  zone_id = aws_route53_zone.rothwell-dev-zone.zone_id
+  name    = "rothwell.dev"
+  type    = "SOA"
+  ttl     = 900
+
+  records = ["ns-865.awsdns-44.net.", "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]
+}
+
+resource "aws_route53_record" "rothwell-dev-a-record" {
+  zone_id = aws_route53_zone.rothwell-dev-zone.zone_id
+  name    = "rothwell.dev"
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.playground_alb_load_balancer.dns_name
+    zone_id                = aws_route53_zone.rothwell-dev-zone.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/dns.tf
+++ b/dns.tf
@@ -17,12 +17,12 @@ resource "aws_route53_record" "rothwell-dev-ns" {
 }
 
 resource "aws_route53_record" "rothwell-dev-soa" {
-  zone_id = aws_route53_zone.rothwell-dev-zone.zone_id
-  name    = "rothwell.dev"
-  type    = "SOA"
-  ttl     = 900
-
-  records = ["ns-865.awsdns-44.net.", "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]
+  allow_overwrite = true
+  zone_id         = aws_route53_zone.rothwell-dev-zone.zone_id
+  name            = "rothwell.dev"
+  type            = "SOA"
+  ttl             = 900
+  records         = ["ns-865.awsdns-44.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]
 }
 
 resource "aws_route53_record" "rothwell-dev-a-record" {
@@ -32,7 +32,7 @@ resource "aws_route53_record" "rothwell-dev-a-record" {
 
   alias {
     name                   = aws_alb.playground_alb_load_balancer.dns_name
-    zone_id                = aws_route53_zone.rothwell-dev-zone.zone_id
+    zone_id                = aws_alb.playground_alb_load_balancer.zone_id
     evaluate_target_health = true
   }
 }

--- a/ecs-alb.tf
+++ b/ecs-alb.tf
@@ -31,13 +31,23 @@ resource "aws_alb_target_group" "playground_app_target_group" {
   }
 }
 
-resource "aws_alb_listener" "alb-listener" {
+resource "aws_alb_listener" "alb-listener-https" {
   load_balancer_arn = aws_alb.playground_alb_load_balancer.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
   certificate_arn   = var.rothwell_dev_acm_cert_arn
 
+  default_action {
+    target_group_arn = aws_alb_target_group.playground_app_target_group.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_listener" "alb-listener-http" {
+  load_balancer_arn = aws_alb.playground_alb_load_balancer.arn
+  port              = "80"
+  protocol          = "HTTP"
   default_action {
     target_group_arn = aws_alb_target_group.playground_app_target_group.arn
     type             = "forward"

--- a/playground-app-service.tf
+++ b/playground-app-service.tf
@@ -15,7 +15,7 @@ resource "aws_ecs_service" "playground_app_service" {
     container_name   = "playground_app"
   }
   network_configuration {
-    security_groups  = [aws_security_group.playground_public_sg.id]
+    security_groups  = [aws_security_group.playground_private_ecs_sg.id]
     subnets          = [aws_subnet.playground_public_sn_01.id, aws_subnet.playground_public_sn_02.id]
     assign_public_ip = true
   }

--- a/vpc.tf
+++ b/vpc.tf
@@ -75,7 +75,7 @@ resource "aws_route_table_association" "playground_public_sn_rt_assn_02" {
   route_table_id = aws_route_table.playground_public_sn_rt_02.id
 }
 
-# ECS Instance Security group
+# ELB Security group
 resource "aws_security_group" "playground_public_sg" {
   name        = "playground_public_sg"
   description = "Test public access security group"
@@ -91,6 +91,13 @@ resource "aws_security_group" "playground_public_sg" {
   ingress {
     from_port   = 80
     to_port     = 80
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -103,7 +110,6 @@ resource "aws_security_group" "playground_public_sg" {
   }
 
   egress {
-    # allow all traffic to private SN
     from_port   = "0"
     to_port     = "0"
     protocol    = "-1"
@@ -112,5 +118,37 @@ resource "aws_security_group" "playground_public_sg" {
 
   tags = {
     Name = "playground_public_sg"
+  }
+}
+
+# ECS Instance Security group
+resource "aws_security_group" "playground_private_ecs_sg" {
+  name        = "playground_private_ecs_sg"
+  description = "private access security group for ECS"
+  vpc_id      = aws_vpc.playground_vpc.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.playground_public_01_cidr, var.playground_public_02_cidr]
+  }
+
+  egress {
+    from_port   = "0"
+    to_port     = "0"
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "playground_private_ecs_sg"
   }
 }


### PR DESCRIPTION
Added route53 section to manage SOA, NS and A records.

Started switching the DNS over from manually stood-up NGINX container in ECS to the one provisioned in this project and started to spot some things missing, like a separate security group for the load balancer and for the ECS cluster and an HTTP listener on the load balancer